### PR TITLE
Fixed version for jest26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 
+.npmrc
 node_modules
 **.tgz
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mock-console",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Jest utility to mock the console",
   "main": "index.js",
   "types": "index.d.ts",
@@ -42,6 +42,9 @@
     "ts-jest": "^27.0.5",
     "ts-jest26": "npm:ts-jest@^26.5.6",
     "typescript": "^4.2.4"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",

--- a/src/setupTestFramework.js
+++ b/src/setupTestFramework.js
@@ -1,9 +1,9 @@
-const originalDescribe = describe;
-
 // Check to see if version before 27 where jasmine is default
 const jestVersion = require("jest/package.json").version;
 const [majorVersion] = jestVersion.split(".");
 if (majorVersion < 27) {
+  const originalDescribe = jasmine.getEnv().describe;
+
   jasmine.getEnv().describe = (
     description,
     specDefinitions,
@@ -26,6 +26,8 @@ if (majorVersion < 27) {
     );
   };
 } else {
+  const originalDescribe = describe;
+
   describe = (description, specDefinitions) => {
     let $jestMockConsoleOriginal;
     const injectedSpecDefinition = (...specArgs) => {


### PR DESCRIPTION
Fixed maximum call stack for jest26 https://github.com/bpedersen/jest-mock-console/issues/26
OriginalDescribe is back to jasmine.getEnv().describe. Otherwise we get a recursive call